### PR TITLE
runAndWaitForBuild - always delete existing build and rebuild

### DIFF
--- a/vars/runAndWaitForBuild.groovy
+++ b/vars/runAndWaitForBuild.groovy
@@ -1,30 +1,18 @@
 #!/usr/bin/groovy
 
-def isFailed(Object build) {
-  def phase = build.status.phase
-  return (phase == "Failed" || phase == "Cancelled" || phase == "Error")
-}
-
 def call(Object ctx, String buildName, Object createFn) {
   ctx.openshift.withCluster() {
     def build = ctx.openshift.selector('build', buildName)
     def buildObject = null
-    def createBuild = false
     try {
       buildObject = build.object()
     } catch (e) {
       buildObject = null
     }
-    if (buildObject == null) {
-      createBuild = true
-    } else if (isFailed(buildObject)) {
+    if (buildObject != null) {
       deleteBuild(ctx, buildName)
-      createBuild = true
     }
-
-    if (createBuild) {
-      createFn()
-    }
+    createFn()
     waitForBuild(ctx, buildName)
   }
 }


### PR DESCRIPTION
Do not skip build if previous build exists, rather delete it and proceed