### PR TITLE
Fix saving of pod logs on saveArtifacts

### DIFF
--- a/vars/saveArtifacts.groovy
+++ b/vars/saveArtifacts.groovy
@@ -5,15 +5,20 @@ def call(Object ctx, String artifactDir, Object selector) {
     selector.withEach() {
       def name = it.name()
       def objectName = name.tokenize("/")[1]
+      def objectType = name.tokenize("/")[0]
       ctx.sh "oc get ${name} -o yaml > ${artifactDir}/${objectName}.yaml"
       ctx.sh "oc describe ${name} > ${artifactDir}/${objectName}.description"
-      if (name.startsWith("pod/")) {
+      if (objectType == "pods") {
         def pod = it.object()
+        for (def i = 0; i < pod.spec.initContainers.size(); i++) {
+          def containerName = pod.spec.initContainers[i].name
+          ctx.sh "oc logs ${name} -c ${containerName} > ${artifactDir}/${objectName}_${containerName}.log"
+        }
         for (def i = 0; i < pod.spec.containers.size(); i++) {
           def containerName = pod.spec.containers[i].name
           ctx.sh "oc logs ${name} -c ${containerName} > ${artifactDir}/${objectName}_${containerName}.log"
         }
-      } else if (name.startsWith("build/")) {
+      } else if (objectType == "build") {
         ctx.sh "oc logs ${name} > ${artifactDir}/${objectName}.log"
       }
     }


### PR DESCRIPTION
The ci plugin uses a prefix of "pods" instead of "pod" on pod objects. Fixing library accordingly.